### PR TITLE
Check for existence of type and type.prototype on children of <Form>

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -81,10 +81,14 @@ export default class Form extends InputContainer {
                 return child;
             }
 
-            if (child.type === ValidatedInput ||
-                child.type.prototype instanceof ValidatedInput ||
-                child.type === RadioGroup ||
-                child.type.prototype instanceof RadioGroup) {
+            if (child.type === ValidatedInput || (
+                child.type && 
+                child.type.prototype != null && (
+                    child.type.prototype instanceof ValidatedInput ||
+                    child.type === RadioGroup ||
+                    child.type.prototype instanceof RadioGroup
+                )
+            )) {
                 let name = child.props && child.props.name;
 
                 if (!name) {


### PR DESCRIPTION
(Testing on react 0.14.2)
Dom form elements are classified only as "block level" and therefore can contain any other inline or block element without restriction. Currently, text nodes cause an error as a child of a `<Form>` when reading the prototype of their type property, as react does not assign them a type. This change also checks if prototype is undefined or null, as it will be for plain object reactDom nodes like `<h1>` or `<p>`, short-circuiting the multiple checks against instanceof.
